### PR TITLE
Enhanced numeric input with bugfixes, scrubbing, scrolling and arrowkeys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11163,11 +11163,6 @@
         "uuid": "^3.2.1"
       }
     },
-    "react-numeric-input": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/react-numeric-input/-/react-numeric-input-2.2.3.tgz",
-      "integrity": "sha1-S/WRjD6v7YUagN8euZLZQQArtVI="
-    },
     "react-select": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "react-hotkeys": "^1.1.4",
     "react-modal": "^3.4.4",
     "react-mosaic-component": "^1.1.1",
-    "react-numeric-input": "^2.2.3",
     "react-select": "^1.2.1",
     "react-tooltip": "^3.6.1",
     "selfsigned": "^1.10.3",

--- a/src/client/editor/components/AmbientLightComponent.js
+++ b/src/client/editor/components/AmbientLightComponent.js
@@ -6,7 +6,7 @@ export default class AmbientLightComponent extends BaseComponent {
 
   static schema = [
     { name: "color", type: types.color, default: "white" },
-    { name: "intensity", type: types.number, default: 1 }
+    { name: "intensity", type: types.number, default: 1, min: 0 }
   ];
 
   updateProperty(propertyName, value) {

--- a/src/client/editor/components/DirectionalLightComponent.js
+++ b/src/client/editor/components/DirectionalLightComponent.js
@@ -9,10 +9,10 @@ export default class DirectionalLightComponent extends BaseComponent {
 
   static schema = [
     { name: "color", type: types.color, default: "white" },
-    { name: "intensity", type: types.number, default: 1 },
+    { name: "intensity", type: types.number, default: 1, min: 0 },
     { name: "castShadow", type: types.boolean, default: true },
-    { name: "elevation", type: types.number, default: 63 },
-    { name: "azimuth", type: types.number, default: 245 }
+    { name: "elevation", type: types.number, default: 63, min: -90, max: 90 },
+    { name: "azimuth", type: types.number, default: 245, min: 0, max: 360 }
   ];
 
   static _tempEuler = new THREE.Euler(0, 0, 0, "YXZ");

--- a/src/client/editor/components/PointLightComponent.js
+++ b/src/client/editor/components/PointLightComponent.js
@@ -6,7 +6,7 @@ export default class PointLightComponent extends BaseComponent {
 
   static schema = [
     { name: "color", type: types.color, default: "white" },
-    { name: "intensity", type: types.number, default: 1 },
+    { name: "intensity", type: types.number, default: 1, min: 0 },
     { name: "castShadow", type: types.boolean, default: true }
   ];
 

--- a/src/client/editor/components/StandardMaterialComponent.js
+++ b/src/client/editor/components/StandardMaterialComponent.js
@@ -13,9 +13,9 @@ export default class StandardMaterialComponent extends SaveableComponent {
   static schema = [
     { name: "color", type: types.color, default: "white" },
     { name: "emissiveFactor", type: types.color, default: "black" },
-    { name: "metallic", type: types.number, default: 1 },
-    { name: "roughness", type: types.number, default: 1 },
-    { name: "alphaCutoff", type: types.number, default: 0.5 },
+    { name: "metallic", type: types.number, default: 1, min: 0, max: 1 },
+    { name: "roughness", type: types.number, default: 1, min: 0, max: 1 },
+    { name: "alphaCutoff", type: types.number, default: 0.5, min: 0, max: 1 },
     { name: "doubleSided", type: types.boolean, default: false },
     { name: "baseColorTexture", type: types.file, default: null, filters: imageFilters },
     { name: "normalTexture", type: types.file, default: null, filters: imageFilters },

--- a/src/client/ui/inputs/NumericInput.js
+++ b/src/client/ui/inputs/NumericInput.js
@@ -1,7 +1,165 @@
 import React from "react";
-import styles from "./NumericInput.scss";
-import ReactNumericInput from "react-numeric-input";
+import PropTypes from "prop-types";
 
-export default function NumericInput(props) {
-  return <ReactNumericInput style={false} className={styles.numericInput} {...props} />;
+import styles from "./NumericInput.scss";
+
+function round(value) {
+  return Math.round(value * 1000) / 1000;
+}
+
+const partialValue = /[-.0]$/;
+const wholeNumber = /-?[0-9]+$/;
+
+export default class NumericInput extends React.Component {
+  static propTypes = {
+    value: PropTypes.number,
+    mediumStep: PropTypes.number,
+    smallStep: PropTypes.number,
+    bigStep: PropTypes.number,
+    onChange: PropTypes.func
+  };
+
+  static defaultProps = {
+    smallStep: 0.1,
+    mediumStep: 1,
+    bigStep: 10
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: props.value.toString(),
+      step: props.mediumStep
+    };
+    this.lastValidValue = this.props.value;
+    window.addEventListener("printstate", () => {
+      console.log("react state", this.props, this.state);
+    });
+  }
+
+  getStepForKeys(ctrlKey, shiftKey) {
+    let step = this.props.mediumStep;
+    if (ctrlKey) {
+      step = this.props.smallStep;
+    } else if (shiftKey) {
+      step = this.props.bigStep;
+    }
+    return step;
+  }
+
+  onKeyDown = e => {
+    const { ctrlKey, shiftKey, key } = e;
+    if (key !== "ArrowUp" && key !== "ArrowDown") return;
+
+    e.preventDefault();
+
+    const step = this.getStepForKeys(ctrlKey, shiftKey);
+    let { value } = this.props;
+    if (key === "ArrowUp") {
+      value += step;
+    } else if (key === "ArrowDown") {
+      value -= step;
+    }
+    value = round(value);
+
+    this.lastValidValue = value;
+    this.props.onChange(value);
+  };
+
+  onWheel = e => {
+    const { ctrlKey, shiftKey, deltaY } = e;
+
+    e.stopPropagation();
+    e.preventDefault();
+
+    const step = this.getStepForKeys(ctrlKey, shiftKey);
+    let { value } = this.props;
+    value += (deltaY > 0 ? 1 : -1) * step;
+    value = round(value);
+
+    this.lastValidValue = value;
+    this.props.onChange(value);
+  };
+
+  setStep = e => {
+    const { ctrlKey, shiftKey } = e;
+    this.setState(prevState => {
+      const newStep = this.getStepForKeys(ctrlKey, shiftKey);
+      if (newStep === prevState.step) return;
+      return { step: newStep };
+    });
+  };
+
+  onMouseDown = e => {
+    e.target.select();
+    e.preventDefault();
+
+    const { ctrlKey, shiftKey } = e;
+    this.setState({ step: this.getStepForKeys(ctrlKey, shiftKey) });
+
+    if (e.button === 1) {
+      document.body.requestPointerLock();
+    }
+
+    window.addEventListener("keydown", this.setStep);
+    window.addEventListener("keyup", this.setStep);
+    window.addEventListener("mousemove", this.onMouseMove);
+    window.addEventListener("mouseup", this.cleanUpListeners);
+  };
+
+  onMouseMove = e => {
+    const value = round(this.props.value + (e.movementX / 100) * this.state.step);
+    this.lastValidValue = value;
+    this.props.onChange(value);
+  };
+
+  cleanUpListeners = () => {
+    document.exitPointerLock();
+    window.removeEventListener("mousemove", this.onMouseMove);
+    window.removeEventListener("keydown", this.setStep);
+    window.removeEventListener("keyup", this.setStep);
+    window.removeEventListener("mouseup", this.cleanUpListeners);
+  };
+
+  validate = () => {
+    this.setState({ value: this.lastValidValue.toString() });
+    this.props.onChange(this.lastValidValue);
+  };
+
+  setValue(value) {
+    const trimmed = value.trim();
+
+    this.setState({ value });
+
+    if (isNaN(trimmed)) return;
+
+    if (wholeNumber.test(trimmed) || (trimmed.length > 0 && !partialValue.test(trimmed))) {
+      const newValue = round(parseFloat(trimmed));
+      this.lastValidValue = newValue;
+      this.props.onChange(newValue);
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const valueChanged = this.props.value !== prevProps.value;
+    const stateIsNotLikeNewVal = parseFloat(this.state.value.trim()) !== this.props.value;
+    if (valueChanged && stateIsNotLikeNewVal) {
+      this.setState({ value: round(this.props.value).toString() });
+    }
+  }
+
+  render() {
+    return (
+      <input
+        className={styles.numericInput}
+        value={this.state.value}
+        onKeyDown={this.onKeyDown}
+        onKeyUp={this.setStep}
+        onMouseDown={this.onMouseDown}
+        onWheel={this.onWheel}
+        onChange={e => this.setValue(e.target.value)}
+        onBlur={this.validate}
+      />
+    );
+  }
 }

--- a/src/client/ui/inputs/NumericInput.js
+++ b/src/client/ui/inputs/NumericInput.js
@@ -32,9 +32,6 @@ export default class NumericInput extends React.Component {
       step: props.mediumStep
     };
     this.lastValidValue = this.props.value;
-    window.addEventListener("printstate", () => {
-      console.log("react state", this.props, this.state);
-    });
   }
 
   getStepForKeys(ctrlKey, shiftKey) {

--- a/src/client/ui/inputs/NumericInput.scss
+++ b/src/client/ui/inputs/NumericInput.scss
@@ -10,10 +10,6 @@
   font-size: 16px;
   height: 24px;
   box-sizing: border-box;
-  -moz-appearance: textfield;
-
-  &::-webkit-outer-spin-button,
-  &::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-  }
+  cursor: col-resize;
+  outline: none;
 }

--- a/src/client/ui/inputs/Vector3Input.scss
+++ b/src/client/ui/inputs/Vector3Input.scss
@@ -2,11 +2,6 @@
   display: flex;
   flex-direction: row;
   flex: 1 1 auto;
-
-  .react-numeric-input {
-    display: flex;
-    flex: 1 1 auto;
-  }
 }
 
 :local(.label) {

--- a/src/client/ui/inputs/componentTypeMappings.js
+++ b/src/client/ui/inputs/componentTypeMappings.js
@@ -9,7 +9,10 @@ import FileInput from "./FileInput";
 /* eslint react/display-name: 0 */
 const componentTypeMappings = new Map([
   [types.color, (value, onChange) => <ColorInput value={value} onChange={onChange} />],
-  [types.number, (value, onChange) => <NumericInput value={value} onChange={onChange} />],
+  [
+    types.number,
+    (value, onChange, { min, max }) => <NumericInput value={value} onChange={onChange} min={min} max={max} />
+  ],
   [types.vector, (value, onChange) => <Vector3Input value={value} onChange={onChange} />],
   [types.euler, (value, onChange) => <EulerInput value={value} onChange={onChange} />],
   [

--- a/src/client/ui/panels/PropertiesPanelContainer.js
+++ b/src/client/ui/panels/PropertiesPanelContainer.js
@@ -121,6 +121,8 @@ class PropertiesPanelContainer extends Component {
 
   getExtras(prop) {
     switch (prop.type) {
+      case types.number:
+        return { min: prop.min, max: prop.max };
       case types.file:
         return { openFileDialog: this.props.openFileDialog, filters: prop.filters };
       default:


### PR DESCRIPTION
Implemented a `NumericInput` that fixes a lot of the flaws of `react-numeric-input`. This avoids messing with your manual typing as much as possible but still fires `onChange` if it sees a valid number while you're typing.
It allows you to edit partial numbers, negative numbers and decimals as if it were a regular old `<input />` and only attempts to validate and reformat the number when you blur the input or a new prop value comes in. 
It also avoids state changes if the incoming prop value is equivalent to, but not exactly, the current input state, so that your typing isn't interrupted by an `onChange` cycle.

In addition to the fixes, it also provides these features:
- Mouse scrubbing with pointer-lock on the middle mouse button
- Scroll wheel scrubbing
- Arrow key increment/decrement
- Varying step sizes toggled on `Ctrl` and `Shift` keys with any of the above input modes

Closes #7 